### PR TITLE
React 18, Property 'children' does not exist

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -67,4 +67,6 @@ export interface IRouterContextProps {
 
   /** current user role that will be validated for accessing a specific route */
   userRole?: string[] | string; // support for multiple roles
+  
+  children?: React.ReactNode;
 }


### PR DESCRIPTION
With React 18 TypeScript, we need to add manually children: ReactNode